### PR TITLE
feat: update highlight color and intro copy

### DIFF
--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -114,7 +114,7 @@ import StackAlt from './assets/stackalt.svg';
   `}
 </style>
 
-# Welcome to Storybook
+# Welcome to the Frontend Design System - v0.1.0
 
 Storybook helps you build UI components in isolation from your app's business logic, data, and context.
 That makes it easy to develop hard-to-reach states. Save these UI states as **stories** to revisit during development, testing, or QA.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,5 @@
 :root {
-  --color-highlight: #FF69B4;
+  --color-highlight: #1DA1F2;
 }
 
 html,


### PR DESCRIPTION
The generated PR Preview should show `v0.1.0` in the Introduction copy, and the highlight colour on the components should be blue.

