### PR TITLE
feat: update highlight colour to hot pink

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sb-pr-preview",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -114,7 +114,7 @@ import StackAlt from './assets/stackalt.svg';
   `}
 </style>
 
-# Welcome to the Frontend Design System - v0.1.1
+# Welcome to the Frontend Design System - v0.1.2
 
 Storybook helps you build UI components in isolation from your app's business logic, data, and context.
 That makes it easy to develop hard-to-reach states. Save these UI states as **stories** to revisit during development, testing, or QA.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,5 @@
 :root {
-  --color-highlight: #1DA1F2;
+  --color-highlight: #FF69B4;
 }
 
 html,
@@ -17,14 +17,4 @@ a {
 
 * {
   box-sizing: border-box;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
 }


### PR DESCRIPTION
Changes the highlight colour to Hot Pink.

The following link is the build from main, and the button should be twitter blue: [Docs Site](https://colpitts-dev.github.io/sb-pr-preview/docs/?path=/story/atoms-button--primary)

The URL generated in the comments below is the preview build for this PR, and the button should be Hot Pink